### PR TITLE
Removing some hardcoded fields

### DIFF
--- a/context.go
+++ b/context.go
@@ -1,14 +1,15 @@
 package swaggering
 
 type Context struct {
-	swaggers   []*Swagger
-	apis       []*Api
-	models     []*Model
-	openModels []*Model
+	packageName string
+	swaggers    []*Swagger
+	apis        []*Api
+	models      []*Model
+	openModels  []*Model
 }
 
-func NewContext() (context *Context) {
-	context = &Context{}
+func NewContext(packageName string) (context *Context) {
+	context = &Context{packageName: packageName}
 	context.swaggers = make([]*Swagger, 0)
 
 	return

--- a/infer_package.go
+++ b/infer_package.go
@@ -1,0 +1,40 @@
+package swaggering
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func InferPackage(dirName string) (packageName string, err error) {
+	goPath, ok := os.LookupEnv("GOPATH")
+	if !ok {
+		err = fmt.Errorf("Cannot infer a package name without $GOPATH")
+		return
+	}
+
+	packageName, err = packageUnderGopath(goPath, dirName)
+
+	return
+}
+
+func packageUnderGopath(goPath, dirName string) (packageName string, err error) {
+	dirName, err = filepath.Abs(dirName)
+	if err != nil {
+		return
+	}
+	dirName = filepath.Clean(dirName)
+
+	goPath = filepath.Join(goPath, "src")
+
+	packageName, err = filepath.Rel(goPath, dirName)
+	if err != nil {
+		return
+	}
+
+	if packageName[0] == '.' {
+		err = fmt.Errorf("Cannot infer package name: target directory is outside of $GOPATH (%q)", goPath)
+	}
+
+	return
+}

--- a/ingester.go
+++ b/ingester.go
@@ -18,8 +18,6 @@ type ServiceApiJSON struct {
 }
 
 func ProcessService(dir string, ingester *Context) {
-	defer log.SetFlags(log.Flags())
-	log.SetFlags(log.Lshortfile)
 	fullpath := filepath.Join(dir, "service.json")
 
 	apis := &ServiceJSON{}

--- a/renderer.go
+++ b/renderer.go
@@ -38,29 +38,29 @@ func (self *{{.GoName}}) FormatJSON() string {
 
 type {{.GoName}}List []*{{.GoName}}
 
-func (list {{.GoName}}List) Populate(jsonReader io.ReadCloser) (err error) {
+func (list *{{.GoName}}List) Populate(jsonReader io.ReadCloser) (err error) {
 	return ReadPopulate(jsonReader, list)
 }
 
-func (list {{.GoName}}List) FormatText() string {
+func (list *{{.GoName}}List) FormatText() string {
 	text := []byte{}
-	for _, dto := range list {
+	for _, dto := range *list {
 		text = append(text, (*dto).FormatText()...)
 		text = append(text, "\n"...)
 	}
 	return string(text)
 }
 
-func (list {{.GoName}}List) FormatJSON() string {
+func (list *{{.GoName}}List) FormatJSON() string {
 	return FormatJSON(list)
 }
 {{/**/ -}}
 `
 	defaultApiTmpl = `
 {{- /**/ -}}
-package client
+package singularity
 
-import "github.com/opentable/singularity/dtos"
+import "{{.BasePackageName}}/dtos"
 
 {{range .Operations}}
 {{- if not .GoTypeInvalid -}}
@@ -88,7 +88,7 @@ func (client *Client) {{.GoMethodName}}(
 	{{if .GoModel -}}
 	{{if eq .GoTypePrefix ""}}
 		response = make({{.GoTypePrefix}}dtos.{{.GoBaseType}}, 0)
-		err = client.DTORequest(response, "{{.Method}}", "{{.Path}}", pathParamMap, queryParamMap
+		err = client.DTORequest(&response, "{{.Method}}", "{{.Path}}", pathParamMap, queryParamMap
 		{{- if .HasBody -}}
 		, body
 		{{- end -}})
@@ -135,8 +135,6 @@ func NewRenderer(tgt string) (renderer *Renderer) {
 }
 
 func RenderService(target string, ingester *Context) {
-	defer log.SetFlags(log.Flags())
-	log.SetFlags(log.Flags() | log.Lshortfile)
 	self := NewRenderer(target)
 	for _, model := range ingester.models {
 		if model.GoUses {

--- a/resolve.go
+++ b/resolve.go
@@ -59,6 +59,7 @@ func resolveApis(context *Context) {
 	var err error
 
 	for _, api := range context.apis {
+		api.BasePackageName = context.packageName
 		for _, op := range api.Operations {
 			op.Path = api.Path
 			op.GoMethodName = capitalize(op.Nickname)

--- a/types.go
+++ b/types.go
@@ -23,6 +23,7 @@ type (
 
 	Api struct {
 		Path, Description string
+		BasePackageName   string
 		Operations        []*Operation
 	}
 


### PR DESCRIPTION
Notably, the name of the target library was hardcoded - now a parameter
to the initial context creation, along with code to infer a name based
on the target directory
